### PR TITLE
Fix track container initialization

### DIFF
--- a/NewProject/Source/MainComponent.cpp
+++ b/NewProject/Source/MainComponent.cpp
@@ -5,18 +5,26 @@ MainComponent::MainComponent()
     addAndMakeVisible(addTrackButton);
     addAndMakeVisible(trackViewport);
 
-    trackViewport.setViewedComponent(&trackContainer, false);
+    trackContainer = std::make_unique<juce::Component>();
+    trackViewport.setViewedComponent(trackContainer.get(), false);
 
     addTrackButton.onClick = [this]() { addNewTrack(); };
     addNewTrack();
     setSize(1000, 600);
 }
 
+MainComponent::~MainComponent() = default;
+
+void MainComponent::paint(juce::Graphics& g)
+{
+    g.fillAll(getLookAndFeel().findColour(juce::ResizableWindow::backgroundColourId));
+}
+
 void MainComponent::addNewTrack()
 {
     auto* track = new MidiTrackComponent();
-    trackContainer.addAndMakeVisible(track);
-    tracks.add(track);
+    trackContainer->addAndMakeVisible(track);
+    midiTracks.add(track);
     resized();
 }
 
@@ -27,10 +35,10 @@ void MainComponent::resized()
     trackViewport.setBounds(area);
 
     int y = 0;
-    for (auto* track : tracks)
+    for (auto* track : midiTracks)
     {
         track->setBounds(0, y, getWidth() - 40, 260);
         y += 270;
     }
-    trackContainer.setSize(getWidth() - 40, y);
+    trackContainer->setSize(getWidth() - 40, y);
 }

--- a/NewProject/Source/MainComponent.h
+++ b/NewProject/Source/MainComponent.h
@@ -10,6 +10,7 @@ public:
     MainComponent();
     ~MainComponent() override;
 
+    void addNewTrack();
     void paint(juce::Graphics&) override;
     void resized() override;
 


### PR DESCRIPTION
## Summary
- allocate the track container before use
- declare addNewTrack and implement destructor & paint
- update layout logic to use midiTracks OwnedArray

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68420a9cd96c832abadf35bd75d3efb9