### PR TITLE
Implement dynamic output routing pairs

### DIFF
--- a/NewProject/Source/MidiTrackOutputRouting.cpp
+++ b/NewProject/Source/MidiTrackOutputRouting.cpp
@@ -5,6 +5,7 @@ MidiTrackOutputRouting::MidiTrackOutputRouting()
     addAndMakeVisible(outputCount);
     outputCount.setRange(1, 8, 1);
     outputCount.setValue(2);
+    outputCount.onValueChange = [this]() { updatePairVisibility(); };
 
     addAndMakeVisible(mode);
     mode.addItemList({ "Duplicated", "Split", "Round Robin" }, 1);
@@ -24,6 +25,9 @@ MidiTrackOutputRouting::MidiTrackOutputRouting()
         splitRanges.add(range);
         addAndMakeVisible(range);
     }
+
+    // Ensure widgets visibility matches the initial outputCount
+    updatePairVisibility();
 }
 
 void MidiTrackOutputRouting::resized()
@@ -32,9 +36,27 @@ void MidiTrackOutputRouting::resized()
     outputCount.setBounds(area.removeFromLeft(100));
     mode.setBounds(area.removeFromLeft(140));
 
-    for (int i = 0; i < outputChannels.size(); ++i)
+    const int count = static_cast<int>(outputCount.getValue());
+    for (int i = 0; i < count; ++i)
     {
         outputChannels[i]->setBounds(area.removeFromLeft(60));
         splitRanges[i]->setBounds(area.removeFromLeft(80));
     }
+}
+
+void MidiTrackOutputRouting::updatePairVisibility()
+{
+    const int count = static_cast<int>(outputCount.getValue());
+
+    for (int i = 0; i < outputChannels.size(); ++i)
+    {
+        const bool visible = i < count;
+        outputChannels[i]->setVisible(visible);
+        splitRanges[i]->setVisible(visible);
+    }
+
+    // Adjust component size to only occupy the space needed for visible pairs
+    const int width = 240 + count * 140; // 100 + 140 + count*(60+80)
+    setSize(width, getHeight());
+    resized();
 }

--- a/NewProject/Source/MidiTrackOutputRouting.h
+++ b/NewProject/Source/MidiTrackOutputRouting.h
@@ -8,6 +8,10 @@ public:
     MidiTrackOutputRouting();
     void resized() override;
 
+    /** Updates visibility of output channel widgets based on the selected
+        output count and resizes the component accordingly. */
+    void updatePairVisibility();
+
     juce::Slider outputCount;
     juce::ComboBox mode;
     juce::OwnedArray<juce::ComboBox> outputChannels;


### PR DESCRIPTION
## Summary
- show only the configured number of output routing pairs
- resize routing component dynamically

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68420e598718832a8658656fbc5c9d46