### PR TITLE
Add README note for IDEPreferLogStreaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# MIDI Divisis
+
+This repository contains a JUCE-based MIDI processing project.
+
+## IDEPreferLogStreaming warning on macOS
+
+When invoking `xcodebuild` on macOS you may see:
+
+```
+warning: IDEPreferLogStreaming is not set, falling back to file loggers
+```
+
+The build will still succeed, so this message can be ignored. If you would like to silence it and see logs streamed as they are produced, set the environment variable:
+
+```sh
+export IDEPreferLogStreaming=YES
+```
+
+before running the build.


### PR DESCRIPTION
## Summary
- document the IDEPreferLogStreaming environment variable for macOS builds

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68420d992714832abed3bd4a185dbee8