### PR TITLE
Fix Unicode dash in MidiTrackOutputRouting

### DIFF
--- a/NewProject/Source/MidiTrackOutputRouting.cpp
+++ b/NewProject/Source/MidiTrackOutputRouting.cpp
@@ -20,7 +20,7 @@ MidiTrackOutputRouting::MidiTrackOutputRouting()
         addAndMakeVisible(ch);
 
         auto* range = new juce::TextEditor();
-        range->setText(juce::String("C1–C3"), juce::dontSendNotification);  // ✅ sécurisé
+        range->setText(juce::String("C1-C3"), juce::dontSendNotification);  // ✅ sécurisé
         splitRanges.add(range);
         addAndMakeVisible(range);
     }


### PR DESCRIPTION
## Summary
- replace en dash with ASCII dash to avoid encoding issues

## Testing
- `cmake ..` *(fails: The source directory does not appear to contain CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_68420d89785c832a9d47999beb22481f