### PR TITLE
Fix default range string

### DIFF
--- a/NewProject/Source/MidiTrackOutputRouting.cpp
+++ b/NewProject/Source/MidiTrackOutputRouting.cpp
@@ -20,7 +20,7 @@ MidiTrackOutputRouting::MidiTrackOutputRouting()
         addAndMakeVisible(ch);
 
         auto* range = new juce::TextEditor();
-        range->setText(juce::String("C1–C3"), juce::dontSendNotification);  // ✅ sécurisé
+        range->setText(juce::String("C1-C3"), juce::dontSendNotification);  // ✅ sécurisé
         splitRanges.add(range);
         addAndMakeVisible(range);
     }


### PR DESCRIPTION
## Summary
- fix invalid dash character in MidiTrackOutputRouting

## Testing
- `g++ -std=c++17 -D JUCE_GLOBAL_MODULE_SETTINGS_INCLUDED=1 -I JUCE/modules -I NewProject/JuceLibraryCode -I NewProject/Source -c NewProject/Source/MidiTrackOutputRouting.cpp -o /tmp/test.o && echo OK`

------
https://chatgpt.com/codex/tasks/task_e_68420e45eb10832aac124f2ab3c80412